### PR TITLE
Add: Adding the ProductNameBlankOrEmpty Exception

### DIFF
--- a/src/main/java/com/compass/products/infrastructure/exceptions/ProductNameBlankOrEmptyException.java
+++ b/src/main/java/com/compass/products/infrastructure/exceptions/ProductNameBlankOrEmptyException.java
@@ -1,0 +1,16 @@
+package com.compass.products.infrastructure.exceptions;
+
+public class ProductNameBlankOrEmptyException extends RuntimeException {
+    
+    private final Integer status;
+
+    public ProductNameBlankOrEmptyException(Integer status, String message) {
+        super(message);
+        this.status = status;
+    }
+
+    public Integer getStatus() {
+        return status;
+    }
+    
+}


### PR DESCRIPTION
In this commit, a new exception was created to prevent the user from creating a product with a blank name or with blank spaces.